### PR TITLE
```

### DIFF
--- a/FrameEmploy/FrameCommon/src/main/java/com/framecommon/framecommon/utils/TokenUtil.java
+++ b/FrameEmploy/FrameCommon/src/main/java/com/framecommon/framecommon/utils/TokenUtil.java
@@ -155,7 +155,6 @@ public class TokenUtil {
     private static String getTokenFromRequest(HttpServletRequest req) {
         String bearerToken = req.getHeader("Authorization");
         if (bearerToken != null && bearerToken.startsWith(TOKEN_PREFIX)) {
-            logger.info("Bearer token found in request.");
             return bearerToken.substring(TOKEN_PREFIX.length());
         }
         return null;


### PR DESCRIPTION
feat(FrameCommon): 移除获取token时的冗余日志输出

在TokenUtil工具类中，从HTTP请求获取Bearer token的方法里，
移除了不必要的info级别日志打印，避免每次请求都产生日志记录，
从而提升性能并减少日志文件的冗余信息。```